### PR TITLE
Adds 'yo' as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   "dependencies": {
     "yeoman-generator": "~0.12.2"
   },
+  "peerDependencies": {
+    "yo": ">=1.0.0-rc.1.1"
+  },
   "devDependencies": {
     "mocha": "~1.8.1"
   },


### PR DESCRIPTION
As `yo` specifies `grunt-cli` and `bower` as peerDependencies, this should allow a `npm install -g generator-flight` to install all three of them globally. Users will no longer need to install them separately prior.
