### PR TITLE
Upgrade Karma config to 0.10 format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 === HEAD
 
 * Add new Google Analytics snippet.
+* Support for Karma 0.10.
 
 === 0.4.1 (August 6, 2013)
 

--- a/lib/templates/application/karma.conf.js
+++ b/lib/templates/application/karma.conf.js
@@ -1,91 +1,74 @@
-// Karma configuration file
+// Karma configuration
 //
 // For all available config options and default values, see:
-// https://github.com/karma-runner/karma/blob/stable/lib/config.js#L54
+// http://karma-runner.github.io/0.10/config/configuration-file.html
 
+module.exports = function (config) {
+  'use strict';
 
-// base path, that will be used to resolve files and exclude
-basePath = '';
+  config.set({
 
-// list of files / patterns to load in the browser
-files = [
-  'app/bower_components/es5-shim/es5-shim.js',
-  'app/bower_components/es5-shim/es5-sham.js',
+    // base path, that will be used to resolve files and exclude
+    basePath: '',
 
-  // frameworks
-  JASMINE,
-  JASMINE_ADAPTER,
-  REQUIRE,
-  REQUIRE_ADAPTER,
+    // frameworks to use
+    frameworks: ['jasmine'],
 
-  // loaded without require
-  'app/bower_components/jquery/jquery.js',
-  'app/bower_components/jasmine-jquery/lib/jasmine-jquery.js',
-  'app/bower_components/jasmine-flight/lib/jasmine-flight.js',
+    // list of files / patterns to load in the browser
+    files: [
+      // loaded without require
+      'app/bower_components/es5-shim/es5-shim.js',
+      'app/bower_components/es5-shim/es5-sham.js',
+      'app/bower_components/jquery/jquery.js',
+      'app/bower_components/jasmine-jquery/lib/jasmine-jquery.js',
+      'app/bower_components/jasmine-flight/lib/jasmine-flight.js',
 
-  // loaded with require
-  {pattern: 'app/bower_components/flight/**/*.js', included: false},
-  {pattern: 'app/js/**/*.js', included: false},
-  {pattern: 'test/spec/**/*.spec.js', included: false},
+      // hack to load RequireJS after the shim libs
+      'node_modules/karma-requirejs/lib/require.js',
+      'node_modules/karma-requirejs/lib/adapter.js',
 
-  'test/test-main.js'
-];
+      // loaded with require
+      {pattern: 'app/bower_components/flight/**/*.js', included: false},
+      {pattern: 'app/js/**/*.js', included: false},
+      {pattern: 'test/spec/**/*.spec.js', included: false},
 
-// list of files to exclude
-exclude = [
-  'app/js/main.js'
-];
+      'test/test-main.js'
+    ],
 
-// use dots reporter, as travis terminal does not support escaping sequences
-// possible values: 'dots', 'progress', 'junit', 'teamcity'
-// CLI --reporters progress
-reporters = [
-  'dots'
-];
+    // list of files to exclude
+    exclude: [
+      'app/js/main.js'
+    ],
 
-// web server port
-// CLI --port 9876
-port = 9876;
+    // test results reporter to use
+    // possible values: 'dots', 'progress', 'junit', 'growl', 'coverage'
+    reporters: ['dots'],
 
-// cli runner port
-// CLI --runner-port 9100
-runnerPort = 9100;
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
 
-// enable / disable colors in the output (reporters and logs)
-// CLI --colors --no-colors
-colors = true;
+    // Start these browsers, currently available:
+    // - Chrome
+    // - ChromeCanary
+    // - Firefox
+    // - Opera
+    // - Safari (only Mac)
+    // - PhantomJS
+    // - IE (only Windows)
+    browsers: [
+      'Chrome',
+      'Firefox'
+    ],
 
-// level of logging
-// possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
-// CLI --log-level debug
-logLevel = LOG_INFO;
+    // If browser does not capture in given timeout [ms], kill it
+    captureTimeout: 5000,
 
-// enable / disable watching file and executing tests whenever any file changes
-// CLI --auto-watch --no-auto-watch
-autoWatch = true;
+    // Continuous Integration mode
+    // if true, it capture browsers, run tests and exit
+    singleRun: false,
 
-// Start these browsers, currently available:
-// - Chrome
-// - ChromeCanary
-// - Firefox
-// - Opera
-// - Safari (only Mac)
-// - PhantomJS
-// - IE (only Windows)
-// CLI --browsers Chrome,Firefox,Safari
-browsers = [
-  'Chrome',
-  'Firefox'
-];
-
-// If browser does not capture in given timeout [ms], kill it
-// CLI --capture-timeout 5000
-captureTimeout = 5000;
-
-// Auto run tests on start (when browsers are captured) and exit
-// CLI --single-run --no-single-run
-singleRun = false;
-
-// report which specs are slower than 500ms
-// CLI --report-slower-than 500
-reportSlowerThan = 500;
+    // Karma will report all the tests that are slower than given time limit (in
+    // ms).
+    reportSlowerThan: 500
+  });
+};

--- a/lib/templates/application/package.json
+++ b/lib/templates/application/package.json
@@ -3,7 +3,14 @@
   "version": "0.0.0",
   "devDependencies": {
     "generator-flight": "~<%= genVersion %>",
-    "karma": "~0.8.5"
+    "karma": "~0.10.0",
+    "karma-jasmine": "~0.1.0",
+    "karma-requirejs": "~0.1.0",
+    "karma-chrome-launcher": "~0.1.0",
+    "karma-ie-launcher": "~0.1.1",
+    "karma-firefox-launcher": "~0.1.0",
+    "karma-phantomjs-launcher": "~0.1.0",
+    "karma-safari-launcher": "~0.1.1"
   },
   "scripts": {
     "test": "./node_modules/.bin/karma start --single-run --browsers PhantomJS"

--- a/package.json
+++ b/package.json
@@ -25,14 +25,15 @@
     "yeoman-generator": "~0.12.2"
   },
   "peerDependencies": {
-    "karma": ">=0.8.5",
+    "karma": ">=0.8.0",
     "yo": ">=1.0.0-rc.1.1"
   },
   "devDependencies": {
     "mocha": "~1.8.1"
   },
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=0.8.0",
+    "npm": ">=1.2.10"
   },
   "licenses": [
     {


### PR DESCRIPTION
Fixes #19

I had to drop es5sh[ia]m from the inclusion list, because I couldn't figure out
how to load them before Require.js is initialized. Since Require.js is now a
framework plugin you can no longer specify a certain point in the inclusion
chain where it should be loaded. Because es5-shim has an UMD header, it tries to
use `define()` which causes an error when invoked from outside of the
Require.js loading cycle.

Any ideas how this could be re-enabled?
