### PR TITLE
Upgrade to yeoman-generator 0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "mocha --no-colors --reporter spec"
   },
   "dependencies": {
-    "yeoman-generator": "~0.12.2"
+    "yeoman-generator": "~0.13.0"
   },
   "peerDependencies": {
     "karma": ">=0.8.0",


### PR DESCRIPTION
Fixes #21

There has been a compatibility issue with `yo` 1.0 and `yeoman-generator` < 0.13, because we removed the dependency on `colors` which was messing around with the String prototype.
