### PR TITLE
Updates Bootstrap to use new repo path

### DIFF
--- a/lib/generators/app/index.js
+++ b/lib/generators/app/index.js
@@ -130,11 +130,10 @@ Generator.prototype.projectFiles = function projectFiles() {
  */
 
 Generator.prototype.importStyles = function createStyles() {
-  var bootstrapPath = 'https://raw.github.com/twitter/bootstrap/gh-pages/assets/css/';
+  var bootstrapPath = 'https://raw.github.com/twbs/bootstrap/gh-pages/dist/css/';
 
   if (this.bootstrap) {
     this.fetch(bootstrapPath + 'bootstrap.css', 'app/css/bootstrap.css', function () {});
-    this.fetch(bootstrapPath + 'bootstrap-responsive.css', 'app/css/bootstrap-responsive.css', function () {});
   }
 };
 

--- a/lib/templates/application/app/main.css
+++ b/lib/templates/application/app/main.css
@@ -1,3 +1,2 @@
 <% if (normalize && !bootstrap) { %>@import "/bower_components/normalize-css/normalize.css";<% } %>
 <% if (bootstrap) { %>@import "bootstrap.css";<% } %>
-<% if (bootstrap) { %>@import "bootstrap-responsive.css";<% } %>


### PR DESCRIPTION
Bootstrap 3.x doesn't need bootstrap-responsive.css any more
