### PR TITLE
Use valid hookFor signature (Fix #28)

### DIFF
--- a/lib/generators/all/index.js
+++ b/lib/generators/all/index.js
@@ -33,11 +33,13 @@ function Generator() {
     }
   });
 
-  this.hookFor('flight:component', {
+  this.hookFor('flight', {
+    as: 'component',
     args: ['my_component']
   });
 
-  this.hookFor('flight:mixin', {
+  this.hookFor('flight', {
+    as: 'mixin',
     args: ['my_mixin']
   });
 


### PR DESCRIPTION
From what I see from the source code managing `hookFor`, it never allowed using subgenerator in its name directly. If it missed a context `as` value, it then appended the current generator path to the string...

This wasn't causing issue before because we recently refactored the lookup and generator resolution logic.

Anyway, this will fix it for now. And we'll fix it upstream in the generator system for next release.
