### PR TITLE
capitalize constructor names

### DIFF
--- a/lib/templates/page.js
+++ b/lib/templates/page.js
@@ -6,7 +6,7 @@ define(function (require) {
    * Module dependencies
    */
 
-  // var myComponent = require('component/my_component');
+  // var MyComponent = require('component/my_component');
 
   /**
    * Module exports
@@ -19,7 +19,7 @@ define(function (require) {
    */
 
   function initialize() {
-    // myComponent.attachTo(document);
+    // MyComponent.attachTo(document);
   }
 
 });


### PR DESCRIPTION
attachTo is called on component constructors not instances—component names in comments capitalized accordingly
