### PR TITLE
Change path to jQuery

### DIFF
--- a/lib/templates/application/app/index.html
+++ b/lib/templates/application/app/index.html
@@ -19,7 +19,7 @@
     <script src="/bower_components/es5-shim/es5-shim.js"></script>
     <script src="/bower_components/es5-shim/es5-sham.js"></script>
     <![endif]-->
-    <script src="/bower_components/jquery/jquery.js"></script><% if (bootstrap) { %>
+    <script src="/bower_components/jquery/dist/jquery.js"></script><% if (bootstrap) { %>
     <script src="/bower_components/components-bootstrap/js/bootstrap.min.js"></script><% } %>
     <script src="/bower_components/requirejs/require.js" data-main="js/main.js"></script>
 <% if (analytics) { %>


### PR DESCRIPTION
The latest version of jQuery available on Bower has moved `jquery.js` to `dist/jquery.js`.

I noticed this when I ran the generator and it failed to find the path to jQuery.
