### PR TITLE
updating jshintrc to add new spyonevent global thats included in jasmine-flight

### DIFF
--- a/lib/templates/application/jshintrc
+++ b/lib/templates/application/jshintrc
@@ -30,6 +30,7 @@
     "expect",
     "it",
     "requirejs",
-    "setupComponent"
+    "setupComponent",
+    "spyOnEvent"
   ]
 }


### PR DESCRIPTION
jshintrc is missing a global defined by jasmine-flight, spyOnEvent
