### PR TITLE
Update karma config to allow requiring of additional bower components

### DIFF
--- a/lib/templates/application/karma.conf.js
+++ b/lib/templates/application/karma.conf.js
@@ -20,7 +20,7 @@ module.exports = function (config) {
       'app/bower_components/jasmine-jquery/lib/jasmine-jquery.js',
       'app/bower_components/jasmine-flight/lib/jasmine-flight.js',
       // loaded with require
-      {pattern: 'app/bower_components/flight/**/*.js', included: false},
+      {pattern: 'app/bower_components/**/*.js', included: false},
       {pattern: 'app/js/**/*.js', included: false},
       {pattern: 'test/spec/**/*.spec.js', included: false},
       // test config


### PR DESCRIPTION
I ran into an issue when attempting to add another bower component and referencing it in my component test - I got an error only in the test "ERROR: 'There is no timestamp for /base/app/bower_components/handlebars/handlebars.js!'"  from karma.  It's a confusing error, and I think we should by default include bower components in karma so that you can require stuff in your app code and it won't break tests - and the solution to that would be to just have karma load all the bower components anyways, I think.
