### PR TITLE
Hardcode node-static dependency version to one that seems to work reliab...

### DIFF
--- a/lib/templates/application/package.json
+++ b/lib/templates/application/package.json
@@ -12,7 +12,7 @@
     "karma-requirejs": "~0.2.1",
     "karma-chrome-launcher": "~0.1.0",
     "karma-firefox-launcher": "~0.1.0",
-    "node-static": "~0.7.3",
+    "node-static": "0.7.4",
     "tiny-lr": "~0.0.5"
   },
   "scripts": {


### PR DESCRIPTION
...ly

It appears from this issue on the node static repo that this is the only version that can be run without crashing after serving one request: https://github.com/cloudhead/node-static/issues/131
